### PR TITLE
[DEF170 on home-tab, changed two instances of 'us' to 'Us'

### DIFF
--- a/components/home-tab.html
+++ b/components/home-tab.html
@@ -156,8 +156,8 @@
 <ion-card class="flex-card">
     <ion-card-header>Useful Links</ion-card-header>
     <ion-card-content>
-        <p><a [navPush]="contactPage">Contact us</a></p>
-        <p><a [navPush]="aboutPage">About us</a></p>
+        <p><a [navPush]="contactPage">Contact Us</a></p>
+        <p><a [navPush]="aboutPage">About Us</a></p>
     </ion-card-content>
 </ion-card>
 


### PR DESCRIPTION
On home page, corrected "About us" and "Contact us" to "About Us" and "Contact Us".