### PR TITLE
[DEF164]

### DIFF
--- a/provider/config.ts
+++ b/provider/config.ts
@@ -31,7 +31,7 @@ export const STRINGS = {
         emergency_contact: 'Emergency Contact',
         tc_version: 'Terms & Conditions',
         password: 'Password',
-        username: 'User Name',
+        username: 'Username',
         password1: 'Password',
         password2: 'Confirm Password',
         email: 'Email',


### PR DESCRIPTION
[DEF164] String constant for username is now "Username" instead of "User Name".

Note: I was unable to change Username error message as requested: "Updated US 3.2.1 - error should say only 'Invalid format'". This error message is returned from the server side.

I did put some commented code in "src/pages/register-login/register-login.ts" to possibly hardcode an error message to match requirement quoted above, instead of taking API respond message. However, this fix would be poor design.