### PR TITLE
[SAVI-LIB 20180405] Updated organization.ts to always use the this.ke…

### DIFF
--- a/service/organization.ts
+++ b/service/organization.ts
@@ -28,11 +28,17 @@ export class OrganizationServices {
         status: <number>{}        
     };
 
-	constructor(private http:Http, public storage:Storage,public userServices:UserServices) {
-		storage.get('key')
-			.then(key => this.key = key)
-			.catch(err => console.log("couldn't get key for authentication"));
-    }
+	constructor(private http:Http, public storage:Storage, private userServices: UserServices) {
+            if(this.userServices.user.id) {
+                this.key = this.userServices.user.id;
+                console.log("using UserServices key!");
+            }
+            else {
+                storage.get('key')
+                    .then(key => this.key = key)
+                    .catch(err => console.log("couldn't get key for authentication"));
+            }
+        }
 
     createOrganization(org : any) : Observable<any>
     {
@@ -42,11 +48,8 @@ export class OrganizationServices {
     }
     getOptions() {
 		let headers = new Headers();
-        if (this.userServices.user) 
-            if (this.userServices.user.id) 
-                headers.append('Authorization', 'Token ' + this.userServices.user.id);
-    
-		
+        headers.append('Authorization', 'Token ' + this.key);
+        console.log("Token: " + this.key);
 		headers.append('Content-Type', 'application/json;q=0.9');
 		headers.append('Accept', 'application/json;q=0.9');
 		return new RequestOptions({headers: headers});
@@ -56,13 +59,13 @@ export class OrganizationServices {
     {
         return this.http.get(SERVER + MY_ORGANIZATIONS_URI, this.getOptions())
         .map(res => res.json())
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getMyOrganizations'));
     }
     getMyPendingOrganizations()
     {
         return this.http.get(SERVER + MY_PENDING_ORGANIZATIONS_URI, this.getOptions())
         .map(res => res.json())
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error')); 
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getMyPendingOrganizations')); 
     }
     getOrganizationContacts(org_id) {
         return this.http.get(SERVER + ORGANIZATIONCONTACTS_URI + org_id , this.getOptions())
@@ -70,7 +73,7 @@ export class OrganizationServices {
             //console.log("res._body = " + res.toString);
             return res.json();
         })
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));  
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getOrganizationContacts'));  
     }
 
     getOrgRequestsRequested() {
@@ -79,13 +82,13 @@ export class OrganizationServices {
             //console.log("res._body = " + res.toString);
             return res.json();
         })
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));  
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getOrgRequestsRequested'));  
     }
     getMyPendingOrganizationsDetails(org_id)
     {
         return this.http.get(SERVER + MY_PENDING_ORGANIZATIONS_URI +org_id +'/', this.getOptions())
         .map(res => res.json())
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error')); 
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getMyPendingOrganizationDetails')); 
     }
     
 
@@ -96,7 +99,7 @@ export class OrganizationServices {
         //console.log("URL:" + SERVER + APPROVE_ORGANIZATION_URI + org_id+"/");
         return this.http.put(SERVER + APPROVE_ORGANIZATION_URI + org_id+"/", this.approve, this.getOptions())
             .map(res => res.json())
-            .catch((error: any) => Observable.throw(error || 'Server error'));
+            .catch((error: any) => Observable.throw(error || 'Server error on approveOrganization'));
     }
     
     getAllOrgNames()
@@ -105,7 +108,7 @@ export class OrganizationServices {
         .map((res : Response) => {
             return res.json();
         })
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));  
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getAllOrgNames'));  
     }
     private handleError(error: any) {
         let errMsg = error._body;
@@ -117,47 +120,48 @@ export class OrganizationServices {
          //console.log("EventId:" + eventId)
           return this.http.get(SERVER + MY_ORG_CONTACTS_URI + eventId +"/", this.getOptions())
         .map(res => res.json())
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getOrgContacts'));
      }
 
      getOrgTypes(){
          //console.log("EventId:" + eventId)
           return this.http.get(SERVER + GET_ORGANIZATION_TYPES_URI, this.getOptions())
         .map(res => res.json())
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getOrgTypes'));
      }
      putOrganizationRequest (orgid,body) {
         return this.http.put(SERVER + MY_PENDING_ORGANIZATIONS_URI+orgid +"/", JSON.stringify(body),this.getOptions())
         
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));  
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on putOrganizationRequest'));  
     }
     putOrgContactsRequest (orgid,body) {
         return this.http.put(SERVER + ORGANIZATIONCONTACTS_URI+orgid +"/", JSON.stringify(body),this.getOptions())
         
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));  
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on putOrgContactsRequest'));  
     }
      getOrgRegistrations(org_id, event_id){
          return this.http.get(SERVER + GET_MYORG_REG_EVENT_URI + org_id + "/" + event_id +"/", this.getOptions())
         .map(res => res.json())
-        .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
+        .catch((error: any) => Observable.throw(error.json().error || 'Server error on getOrgRegistrations'));
      }
     
-     groupRegisterForEvent(org_id, event_id, members, notification){
-         let data = {"options":{"notification_option":0}, "members":[]};
-         data.options ={"notification_option":notification};
-      //   data.options= {"options":options};
-      
+    groupRegisterForEvent(org_id, event_id, members, notification) {
+        let data = { "options": { "notification_option": 0 }, "members": [] };
+        data.options = { "notification_option": notification };
+        //   data.options= {"options":options};
+
         data.members = members;
-         console.log(JSON.stringify(data));
-  return this.http.post(SERVER + GET_MYORG_REG_EVENT_URI + org_id + "/" + event_id + "/", data, this.getOptions())
-        .map(res => res.json())
-        .catch(this.handleError);
-     }
+        console.log(JSON.stringify(data));
+        return this.http.post(SERVER + GET_MYORG_REG_EVENT_URI + org_id + "/" + event_id + "/", data, this.getOptions())
+            .map(res => res.json())
+            .catch(this.handleError);
+    }
+
      getAllOrganizationTypes()
      {
          return this.http.get(SERVER + ALL_ORGANIZATIONTYPES_URI, this.getOptions())
          .map(res => res.json())
-         .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
+         .catch((error: any) => Observable.throw(error.json().error || 'Server error on getAllOrganizationTypes'));
      } 
      
     public createGroup(groupData : any, membersData : any[]) : Observable<any> {
@@ -175,7 +179,7 @@ export class OrganizationServices {
      {
          return this.http.get(SERVER + ALL_GROUPS_URI, this.getOptions())
          .map(res => res.json())
-         .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
+         .catch((error: any) => Observable.throw(error.json().error || 'Server error on getAllGroups'));
      } 
      
 }


### PR DESCRIPTION
changed source of this.key to first try UserServices and then use the storage key.  Also added context to the server error messages since this code works in Chrome but not in FF and probably IE.  this will help out in debugging. This is the only other place so far that had the storage key usage.  I'll double check tonight.