### PR TITLE
Fixed the cached observable problem - was missing refCount

### DIFF
--- a/service/user.ts
+++ b/service/user.ts
@@ -89,7 +89,9 @@ export class UserServices {
         if(!this._myPreferences) {
             console.info("actual http:// getMyPreferences called!!");
             this._myPreferences = this.http.get(SERVER + GET_MY_PREFERENCES_URI, this.getOptions())
-                .map(res => res.json()).publishReplay(1)
+                .map(res => res.json())
+                .publishReplay(1)
+                .refCount()
                 .catch((error: any) => Observable.throw(error || 'Server error'));
         }
         else {
@@ -109,6 +111,7 @@ export class UserServices {
                     console.info("user.getMyProfile observable has 'nexted' ")
                     return userServicesThis.user.profile;
                 }).publishReplay(1)
+                .refCount()
                 .catch((error: any) => Observable.throw(error || 'Server error'));
         }
         else {


### PR DESCRIPTION
publishReplay(1) returns a connectable observable, which requires a connect to subscribe. Observable ForkJoin doesn't work with connectable observables, thus never finishing.
Adding a refcount after publishReplay(1) allows it to be subscribed.
https://blog.angularindepth.com/rxjs-how-to-use-refcount-73a0c6619a4e