### PR TITLE
Service changes to allow a group admin to 'unregister/cancel' an event for a group

### DIFF
--- a/model/myEvent.ts
+++ b/model/myEvent.ts
@@ -15,4 +15,9 @@ export class MyEvent {
   notification_options: string;
   event_notification_schedule: string;
   overlap_override: boolean;
+
+  // added as optional to cover events returned from events/myevents
+  organization_id?: number;
+  organization_name?:string;
+  organization_group?:string;
 }

--- a/service/signupassistant.ts
+++ b/service/signupassistant.ts
@@ -207,7 +207,7 @@ export class SignupAssistant {
             .eventDeregisterGroup(event_id, org_id).subscribe(
                 result => {
                     console.log("canceled event registration " + event_id + " for group " + org_id);
-                    this.presentToast("The group is longer signed up for this event");
+                    this.presentToast("The group is no longer registered for this event");
                     this.iscancelSignup = true;
                 },
                 err => {

--- a/service/signupassistant.ts
+++ b/service/signupassistant.ts
@@ -185,22 +185,40 @@ export class SignupAssistant {
             });
     }
   
-  deRegister(id) {
-       this.volunteerEventsService
-          .eventDeregister(id).subscribe(
-          result => {
-              console.log("canceled event registration " + id);
-              this.presentToast("You are no longer signed up for this event");
-              this.iscancelSignup= true;
-          },
-          err => {
-              console.log(err);
-              this.presentToast("Error cancelling event registration");
-              this.iscancelSignup = false;
-          }, () => {
-              this.volunteerEventsService.loadMyEvents();
-          });
-  }
+    deRegister(id) {
+        this.volunteerEventsService
+            .eventDeregister(id).subscribe(
+                result => {
+                    console.log("canceled event registration " + id);
+                    this.presentToast("You are no longer signed up for this event");
+                    this.iscancelSignup = true;
+                },
+                err => {
+                    console.log(err);
+                    this.presentToast("Error cancelling event registration");
+                    this.iscancelSignup = false;
+                }, () => {
+                    this.volunteerEventsService.loadMyEvents();
+                });
+    }
+
+    deregisterGroup(event_id: string, org_id: string) {
+        this.volunteerEventsService
+            .eventDeregisterGroup(event_id, org_id).subscribe(
+                result => {
+                    console.log("canceled event registration " + event_id + " for group " + org_id);
+                    this.presentToast("The group is longer signed up for this event");
+                    this.iscancelSignup = true;
+                },
+                err => {
+                    console.log(err);
+                    this.presentToast("Error cancelling event registration");
+                    this.iscancelSignup = false;
+                }, () => {
+                    this.volunteerEventsService.loadMyEvents();
+                });
+    }
+
 
   cancelEventRegisteration(id): boolean {
       let confirm = this.alertCtrl.create({
@@ -209,16 +227,11 @@ export class SignupAssistant {
           message: 'Are you sure you want to cancel this event Registration?',
           buttons: [
               {
-                  text: 'No',
-                  handler: () => {
-                      console.log('No clicked');
-                  }  
-                               
+                  text: 'No'   
               },
               {
                   text: 'Yes',
                   handler: () => {
-                      console.log('Yes clicked');
                       return this.deRegister(id);
                   }
               }
@@ -228,4 +241,29 @@ export class SignupAssistant {
       confirm.present();
       return this.iscancelSignup;
   }
+    cancelGroupEventRegistration(event_id: string, org_id: string): boolean {
+        const confirm = this.alertCtrl.create({
+            title: 'Group Cancellation Confirmation',
+            cssClass: 'alertReminder',
+            message: 'Are you sure you want to cancel this event Registration for this group?',
+            buttons: [
+                {
+                    text: 'No',
+                    handler: () => {
+                        console.log('No clicked');
+                    }
+                },
+                {
+                    text: 'Yes',
+                    handler: () => {
+                        console.log('Yes clicked');
+                        return this.deregisterGroup(event_id, org_id);
+                    }
+                }
+            ]
+
+        });
+        confirm.present();
+        return this.iscancelSignup;
+    }
 }

--- a/service/volunteer-events-service.ts
+++ b/service/volunteer-events-service.ts
@@ -5,7 +5,7 @@ import { VolunteerEvent } from '../model/volunteer-event';
 import { MyEvent } from '../model/myEvent';
 import { EventImage } from '../model/eventImage';
 import { EventDetail } from '../model/event-detail';
-import { GET_EVENTS_URI } from '../provider/config';
+import { GET_EVENTS_URI, GET_MYORG_REG_EVENT_URI } from '../provider/config';
 import { GET_EVENT_DETAILS_URI } from '../provider/config';
 import { GET_ADMIN_EVENTS_URI } from '../provider/config';
 import { GET_ADMIN_EVENT_DETAILS_URI } from '../provider/config';
@@ -18,6 +18,7 @@ import { UserServices } from '../service/user';
 import { GET_EVENTS_REPORT_URI } from '../provider/config';
 import { EVENT_CATEGORIES_URI } from '../provider/config';
 import { CHECK_MY_EVENTS_URI } from '../provider/config';
+import { group } from '@angular/core/src/animation/dsl';
 
 
 @Injectable()
@@ -74,6 +75,7 @@ export class VolunteerEventsService {
             .map(res => res.json())
             .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
     }
+
     getVolunteerEventsMaxTime(maxTime: string): Observable<VolunteerEvent[]> {
         return this.http.get(SERVER + GET_EVENTS_URI + "?timeMax=" + maxTime)
             .map(res => res.json())
@@ -111,19 +113,33 @@ export class VolunteerEventsService {
             .map(res => res.json())
             .catch((error: any) => Observable.throw(error || 'Server error'));
     }
+
     eventDeregister(eventId: string): Observable<any> {
         return this.http.delete(SERVER + EVENT_SIGNUP_URI + eventId + "/", this.getOptions())
             .map(res => res)
             .catch((error: any) => Observable.throw(error || 'Server error'));
     }
-    getMyEvents(token: number): Observable<MyEvent[]> {
-        //let header = new Headers();
-        //header.append('Authorization', 'Token ' + token);
-        //let requestoption = new RequestOptions({ headers: header });
+
+    eventDeregisterGroup(eventId: string, groupId: string): Observable<any> {
+        return this.http.delete(SERVER + GET_MYORG_REG_EVENT_URI + eventId + "/" + groupId + "/", this.getOptions())
+            .map(res => res)
+            .catch((error: any) => Observable.throw(error || 'Server error'));
+    }
+    
+    getMyEvents(): Observable<MyEvent[]> {
+
         return this.http.get(SERVER + GET_MYEVENTS_URI, this.getOptions())
             .map(res => res.json())
             .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
     }
+    
+    getMyEvent(eventId: string): Observable<MyEvent[]> {
+
+        return this.http.get(SERVER + GET_MYEVENTS_URI + eventId + '/', this.getOptions())
+            .map(res => res.json())
+            .catch((error: any) => Observable.throw(error.json().error || 'getMyEvent: Server error'));
+    }
+
     getEventImage(eventID: string): Observable<EventImage[]> {
         return this.http.get(SERVER + GET_EVENT_IMAGE_URI + eventID + "/")
             .map(res => res.json())
@@ -131,7 +147,7 @@ export class VolunteerEventsService {
     }
     loadMyEvents() {
         if (this.userServices.user.id) {
-            this.getMyEvents(this.userServices.user.id).subscribe(
+            this.getMyEvents().subscribe(
                 myEvents => this.myEvents = myEvents,
                 err => {
                     console.log(err);

--- a/service/volunteer-events-service.ts
+++ b/service/volunteer-events-service.ts
@@ -121,7 +121,7 @@ export class VolunteerEventsService {
     }
 
     eventDeregisterGroup(eventId: string, groupId: string): Observable<any> {
-        return this.http.delete(SERVER + GET_MYORG_REG_EVENT_URI + eventId + "/" + groupId + "/", this.getOptions())
+        return this.http.delete(SERVER + GET_MYORG_REG_EVENT_URI + groupId + "/" + eventId + "/", this.getOptions())
             .map(res => res)
             .catch((error: any) => Observable.throw(error || 'Server error'));
     }


### PR DESCRIPTION
This was not possible before as any cancel/deregister would be done at the individual level only.